### PR TITLE
allows peer-grader to be preloaded in /mod

### DIFF
--- a/database.php
+++ b/database.php
@@ -26,7 +26,7 @@ array( "{$CFG->dbprefix}peer_assn",
     json       TEXT NULL,
 
     updated_at  TIMESTAMP NULL,
-    created_at  TIMESTAMP NOT NULL,
+    created_at  TIMESTAMP NOT NULL DEFAULT '1970-01-02 00:00:00',
 
     CONSTRAINT `{$CFG->dbprefix}peer_assn_ibfk_1`
         FOREIGN KEY (`link_id`)
@@ -54,8 +54,8 @@ array( "{$CFG->dbprefix}peer_submit",
 
     rating     INTEGER NULL,  -- Aggregate rating
 
-    updated_at TIMESTAMP NOT NULL,
-    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT '1970-01-02 00:00:00',
+    created_at TIMESTAMP NOT NULL DEFAULT '1970-01-02 00:00:00',
 
     CONSTRAINT `{$CFG->dbprefix}peer_submit_ibfk_1`
         FOREIGN KEY (`user_id`)
@@ -79,8 +79,8 @@ array( "{$CFG->dbprefix}peer_text",
     data         TEXT NULL,
     json         TEXT NULL,
 
-    updated_at  TIMESTAMP NOT NULL,
-    created_at  TIMESTAMP NOT NULL,
+    updated_at  TIMESTAMP NOT NULL DEFAULT '1970-01-02 00:00:00',
+    created_at  TIMESTAMP NOT NULL DEFAULT '1970-01-02 00:00:00',
 
     CONSTRAINT `{$CFG->dbprefix}peer_text_ibfk_1`
         FOREIGN KEY (`assn_id`)
@@ -106,8 +106,8 @@ array( "{$CFG->dbprefix}peer_grade",
 
     json         TEXT NULL,
 
-    updated_at  TIMESTAMP NOT NULL,
-    created_at  TIMESTAMP NOT NULL,
+    updated_at  TIMESTAMP NOT NULL DEFAULT '1970-01-02 00:00:00',
+    created_at  TIMESTAMP NOT NULL DEFAULT '1970-01-02 00:00:00',
 
     CONSTRAINT `{$CFG->dbprefix}peer_grade_ibfk_1`
         FOREIGN KEY (`submit_id`)
@@ -131,8 +131,8 @@ array( "{$CFG->dbprefix}peer_flag",
 
     json         TEXT NULL,
 
-    updated_at  TIMESTAMP NOT NULL,
-    created_at  TIMESTAMP NOT NULL,
+    updated_at  TIMESTAMP NOT NULL DEFAULT '1970-01-02 00:00:00',
+    created_at  TIMESTAMP NOT NULL DEFAULT '1970-01-02 00:00:00',
 
     CONSTRAINT `{$CFG->dbprefix}peer_flag_ibfk_1`
         FOREIGN KEY (`submit_id`)


### PR DESCRIPTION
I was having similar issues to https://github.com/tsugiproject/tsugi/pull/39 when trying to preload this into /mod for my docker project. This fixes that issue for me, but I see that there's a bunch of update tables on 190-222. Do those not get called the first run through because $DATABASE_UPGRADE ≠ $DATABASE_INSTALL ?